### PR TITLE
fix: Remove duplicated messages from showing up

### DIFF
--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -185,7 +185,6 @@ class MessageHistoryComponent
       content: content,
     }
     ContactService.addMessage(this.contact.did, message)
-    this.messages.push(message)
     m.redraw()
   }
 


### PR DESCRIPTION
Fixes duplicate messages from showing up when sending a message as well as an issue where multiple messages were being shown, multiplied by the number of connections.