### PR TITLE
Feat: Send profile info

### DIFF
--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -67,7 +67,8 @@ export class Agent {
     const to = message.to[0] == this.profile.did ? this.profile as Contact : ContactService.getContact(message.to[0])
     eventbus.emit("messageReceived", {sender: from, receiver: to, message})
     eventbus.emit(message.type, {sender: from, receiver: to, message})
-    if(ContactService.getContact(message.from)) {
+    if(ContactService.getContact(message.from) &&
+       message.type == "https://didcomm.org/basicmessage/2.0/message") {
       let fromName = message.from;
       if(from)
         fromName = from.label || from.did;


### PR DESCRIPTION
When we get a connection that we don't know about, we first ask them who they are. If we receive a request for *our* profile, we respond with our display name. This is a *very* rudimentary implementation of the [user profile protocol](https://didcomm.org/user-profile/1.0/). Enough so that we don't have very long DIDs breaking the UI.